### PR TITLE
Fix downloading TS3 client

### DIFF
--- a/discord/install.sh
+++ b/discord/install.sh
@@ -22,7 +22,7 @@ case "$1" in
 "teamspeak")
 	echo "Installing TeamSpeak Client..."
 	# Get latest TeamSpeak client download URL
-	DOWNLOAD_URL=$(curl -s https://www.teamspeak.com/versions/client.json | jq -r '.linux.x86_64.mirrors["4Netplayers.de"]')
+	DOWNLOAD_URL=$(curl -s https://www.teamspeak.com/versions/client.json | jq -r '.linux.x86_64.mirrors["teamspeak.com"]')
 
 	# Download TeamSpeak client
 	echo "Downloading TeamSpeak Client..."


### PR DESCRIPTION
The latest docker image is missing the Teamspeak client:

> Could not find TeamSpeak 3 Client: stat /opt/sinusbot/TeamSpeak3-Client-linux_amd64/ts3client_linux_amd64: no such file or directory

This commit updates the installer to use the default mirror (`4Netplayers.de` is no longer listed in `client.json`).