### PR TITLE
Fix: raised discord docker python version to 3.11 (#62)

### DIFF
--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 LABEL description="SinusBot - Discord only image"
-LABEL version="1.0.2"
+LABEL version="1.0.3"
 
 # Install dependencies and clean up afterwards
 RUN apt-get update && \

--- a/discord/Dockerfile
+++ b/discord/Dockerfile
@@ -5,8 +5,9 @@ LABEL version="1.0.2"
 
 # Install dependencies and clean up afterwards
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates bzip2 unzip curl python3 procps libpci3 libxslt1.1 libxkbcommon0 locales && \
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates bzip2 unzip curl python3.11 procps libpci3 libxslt1.1 libxkbcommon0 locales && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* && \
+    ln -s /usr/bin/python3.11 /usr/bin/python3
 
 # Set locale
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen


### PR DESCRIPTION
- During installation, Python version 3.11 is requested
- Created a symbolic link to the installed Python for python3
- The Debian version was updated to Bookworm due to the archiving of the Debian Buster repositories